### PR TITLE
fix: UI fixes, campus rep flow, dashboard filters, and auth port updates

### DIFF
--- a/back-end/controllers/adminController.js
+++ b/back-end/controllers/adminController.js
@@ -6,7 +6,11 @@ const getDashboard = (req, res) => {
 };
 
 const getPending = (req, res) => {
-  res.json([...pendingCourses, ...pendingResources]);
+  const { kind, category } = req.query;
+  let items = [...pendingCourses, ...pendingResources];
+  if (kind) items = items.filter((i) => i.kind.toLowerCase() === kind.toLowerCase());
+  if (category) items = items.filter((i) => i.category.toLowerCase() === category.toLowerCase());
+  res.json(items);
 };
 
 const getCourseById = (req, res) => {

--- a/front-end/src/pages/AdminLogin.jsx
+++ b/front-end/src/pages/AdminLogin.jsx
@@ -29,7 +29,7 @@ function AdminLogin() {
     setError("");
 
     try {
-      const res = await fetch("http://localhost:3001/api/auth/campus-rep/login", {
+      const res = await fetch("http://localhost:5001/api/auth/campus-rep/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),

--- a/front-end/src/pages/CampRepDashboard.jsx
+++ b/front-end/src/pages/CampRepDashboard.jsx
@@ -4,15 +4,19 @@ import { useVerification } from "../context/VerificationContext";
 import "./CampRepDashboard.css";
 
 const API_BASE = process.env.REACT_APP_API_URL || "http://localhost:5001/api";
-const FILTERS = ["Recent", "Pending+", "Category+"];
 
 const CampRepDashboard = () => {
-  const [activeFilter, setActiveFilter] = useState(null);
+  const [kind, setKind] = useState("");
+  const [category, setCategory] = useState("");
   const [pendingItems, setPendingItems] = useState([]);
   const { verifiedCourses, verifiedResources } = useVerification();
 
   useEffect(() => {
-    fetch(`${API_BASE}/admin/pending`)
+    const params = new URLSearchParams();
+    if (kind) params.append("kind", kind);
+    if (category) params.append("category", category);
+
+    fetch(`${API_BASE}/admin/pending?${params.toString()}`)
       .then((res) => res.json())
       .then((data) => {
         const items = data.map((item) => ({
@@ -24,10 +28,8 @@ const CampRepDashboard = () => {
         }));
         setPendingItems(items);
       })
-      .catch(() => {
-        // Fallback: leave list empty on error
-      });
-  }, []);
+      .catch(() => {});
+  }, [kind, category]);
 
   return (
     <div className="campRepDash">
@@ -46,15 +48,22 @@ const CampRepDashboard = () => {
         <h1 className="campRepDashTitle">Dash board</h1>
 
         <div className="campRepFilters">
-          {FILTERS.map((f) => (
-            <button
-              key={f}
-              className={`campRepFilterBtn${activeFilter === f ? " campRepFilterBtn--active" : ""}`}
-              onClick={() => setActiveFilter(activeFilter === f ? null : f)}
-            >
-              {f}
-            </button>
-          ))}
+          <select className="campRepFilterBtn" value={kind} onChange={(e) => setKind(e.target.value)}>
+            <option value="">Type</option>
+            <option value="Course">Course</option>
+            <option value="Resource">Resource</option>
+          </select>
+          <select className="campRepFilterBtn" value={category} onChange={(e) => setCategory(e.target.value)}>
+            <option value="">Category</option>
+            <option value="Notes">Notes</option>
+            <option value="Practice Questions">Practice Questions</option>
+            <option value="Flashcards">Flashcards</option>
+            <option value="Videos">Videos</option>
+            <option value="Computer Science">Computer Science</option>
+            <option value="Mathematics">Mathematics</option>
+            <option value="History">History</option>
+            <option value="Physics">Physics</option>
+          </select>
         </div>
 
         <div className="campRepStatsCard">

--- a/front-end/src/pages/CampusRepDetails.jsx
+++ b/front-end/src/pages/CampusRepDetails.jsx
@@ -23,7 +23,7 @@ const CampusRepDetailsScreen = () => {
             <input type="text" placeholder="Computer Science" />
           </div>
 
-          <button className="primary-btn" onClick={() => navigate('/verifying')}>
+          <button className="primary-btn" onClick={() => navigate('/camp-rep-dashboard')}>
             Next
           </button>
 

--- a/front-end/src/pages/Login.jsx
+++ b/front-end/src/pages/Login.jsx
@@ -29,7 +29,7 @@ function Login() {
     setError("");
 
     try {
-      const res = await fetch("http://localhost:3001/api/auth/login", {
+      const res = await fetch("http://localhost:5001/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),
@@ -95,7 +95,7 @@ function Login() {
           Log in
         </button>
 
-        <div className="divider">Or continue with</div>
+        {/* <div className="divider">Or continue with</div>
 
         <div className="social-buttons">
           <button type="button" className="social-btn">
@@ -106,7 +106,7 @@ function Login() {
             <img src="https://www.svgrepo.com/show/452229/apple.svg" alt="Apple" width="20" height="20" style={{filter: "invert(1)"}} />
             Sign in with Apple
           </button>
-        </div>
+        </div> */}
 
         <p className="auth-footer-text">
           Sign in as a <Link to="/admin-login">Campus Rep</Link>

--- a/front-end/src/pages/SignUp.jsx
+++ b/front-end/src/pages/SignUp.jsx
@@ -32,7 +32,7 @@ function Signup() {
     setError("");
 
     try {
-      const res = await fetch("http://localhost:3001/api/auth/signup", {
+      const res = await fetch("http://localhost:5001/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),

--- a/front-end/src/pages/Verifying.jsx
+++ b/front-end/src/pages/Verifying.jsx
@@ -11,7 +11,7 @@ const VerifyingScreen = () => {
       <div className="success-content mb-auto flex flex-col items-center">
         <h2 className="success-title mb-6">Verifying your account</h2>
         <p className="auth-footer-text">We are reviewing your transcript. You will be notified once your campus rep account is verified.</p>
-        <button className="primary-btn mt-8" onClick={() => navigate('/success')}>Done</button>
+        <button className="primary-btn mt-8" onClick={() => navigate('/camp-rep-dashboard')}>Done</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Fixed auth API port from 3001 to 5001 in Login, SignUp, and AdminLogin
- Campus rep details "Next" now goes directly to dashboard (skips verification page)
- Verifying page "Done" also routes to campus rep dashboard
- Replaced dashboard filter buttons with dropdowns that query the backend by kind/category
- Commented out Google and Apple sign-in buttons until OAuth is implemented

## Test plan
- [ ] Login, signup, and campus rep login hit correct port (5001)
- [ ] Filling campus rep details and clicking Next lands on dashboard
- [ ] Dashboard Type and Category dropdowns filter the pending list correctly
- [ ] Google/Apple buttons no longer visible on login page