### PR TITLE
feat: add MongoDB auth with bcrypt, JWT, and role selection

### DIFF
--- a/back-end/middleware/authMiddleware.js
+++ b/back-end/middleware/authMiddleware.js
@@ -1,0 +1,19 @@
+const jwt = require("jsonwebtoken");
+
+const protect = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "No token provided" });
+  }
+
+  const token = authHeader.split(" ")[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch {
+    return res.status(401).json({ error: "Invalid or expired token" });
+  }
+};
+
+module.exports = { protect };

--- a/back-end/models/User.js
+++ b/back-end/models/User.js
@@ -1,0 +1,33 @@
+const mongoose = require("mongoose");
+const bcrypt = require("bcryptjs");
+
+const userSchema = new mongoose.Schema(
+  {
+    fullName: { type: String, required: true, trim: true },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    password: { type: String, required: true },
+    role: {
+      type: String,
+      enum: ["student", "campus-rep", "admin"],
+      default: "student",
+    },
+  },
+  { timestamps: true }
+);
+
+userSchema.pre("save", async function () {
+  if (!this.isModified("password")) return;
+  this.password = await bcrypt.hash(this.password, 12);
+});
+
+userSchema.methods.comparePassword = function (candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+module.exports = mongoose.model("User", userSchema);

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -11,9 +11,13 @@
   },
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "express-validator": "^7.3.2",
+    "jsonwebtoken": "^9.0.3",
+    "mongoose": "^9.5.0"
   },
   "devDependencies": {
     "c8": "^11.0.0",

--- a/back-end/routes/auth.js
+++ b/back-end/routes/auth.js
@@ -1,81 +1,146 @@
 const express = require("express");
+const jwt = require("jsonwebtoken");
+const { body, validationResult } = require("express-validator");
+const User = require("../models/User");
+const { protect } = require("../middleware/authMiddleware");
 
 const router = express.Router();
 
-// In-memory mock user store (no database this sprint)
-const users = [];
-const campusReps = [
-  { id: "rep-1", email: "rep@school.edu", password: "rep123", name: "Campus Rep" },
-];
+const signToken = (user) =>
+  jwt.sign(
+    { id: user._id, email: user.email, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: "7d" }
+  );
 
 // POST /api/auth/signup
-router.post("/signup", (req, res) => {
-  const { fullName, email, password, confirmPassword } = req.body;
+router.post(
+  "/signup",
+  [
+    body("fullName").trim().notEmpty().withMessage("Full name is required"),
+    body("email").isEmail().withMessage("Valid email is required").normalizeEmail(),
+    body("password").isLength({ min: 6 }).withMessage("Password must be at least 6 characters"),
+    body("confirmPassword").notEmpty().withMessage("Confirm password is required"),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ error: errors.array()[0].msg });
+    }
 
-  if (!fullName || !email || !password || !confirmPassword) {
-    return res.status(400).json({ error: "All fields are required" });
+    const { fullName, email, password, confirmPassword } = req.body;
+
+    if (password !== confirmPassword) {
+      return res.status(400).json({ error: "Passwords do not match" });
+    }
+
+    try {
+      const existing = await User.findOne({ email });
+      if (existing) {
+        return res.status(409).json({ error: "Email already in use" });
+      }
+
+      const user = await User.create({ fullName, email, password, role: "student" });
+      const token = signToken(user);
+
+      return res.status(201).json({
+        message: "Account created successfully",
+        token,
+        user: { id: user._id, fullName: user.fullName, email: user.email, role: user.role },
+      });
+    } catch (err) {
+      console.error("Signup error:", err.message);
+      return res.status(500).json({ error: "Server error", detail: err.message });
+    }
   }
-
-  if (password !== confirmPassword) {
-    return res.status(400).json({ error: "Passwords do not match" });
-  }
-
-  const existingUser = users.find((u) => u.email === email);
-  if (existingUser) {
-    return res.status(409).json({ error: "Email already in use" });
-  }
-
-  const newUser = {
-    id: `user-${Date.now()}`,
-    fullName,
-    email,
-    password,
-    role: "student",
-  };
-  users.push(newUser);
-
-  return res.status(201).json({
-    message: "Account created successfully",
-    user: { id: newUser.id, fullName: newUser.fullName, email: newUser.email, role: newUser.role },
-  });
-});
+);
 
 // POST /api/auth/login
-router.post("/login", (req, res) => {
-  const { email, password } = req.body;
+router.post(
+  "/login",
+  [
+    body("email").isEmail().withMessage("Valid email is required").normalizeEmail(),
+    body("password").notEmpty().withMessage("Password is required"),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ error: errors.array()[0].msg });
+    }
 
-  if (!email || !password) {
-    return res.status(400).json({ error: "Email and password are required" });
+    const { email, password } = req.body;
+
+    try {
+      const user = await User.findOne({ email });
+      if (!user || !(await user.comparePassword(password))) {
+        return res.status(401).json({ error: "Invalid email or password" });
+      }
+
+      const token = signToken(user);
+
+      return res.status(200).json({
+        message: "Login successful",
+        token,
+        user: { id: user._id, fullName: user.fullName, email: user.email, role: user.role },
+      });
+    } catch (err) {
+      return res.status(500).json({ error: "Server error" });
+    }
   }
-
-  const user = users.find((u) => u.email === email && u.password === password);
-  if (!user) {
-    return res.status(401).json({ error: "Invalid email or password" });
-  }
-
-  return res.status(200).json({
-    message: "Login successful",
-    user: { id: user.id, fullName: user.fullName, email: user.email, role: user.role },
-  });
-});
+);
 
 // POST /api/auth/campus-rep/login
-router.post("/campus-rep/login", (req, res) => {
-  const { email, password } = req.body;
+router.post(
+  "/campus-rep/login",
+  [
+    body("email").isEmail().withMessage("Valid email is required").normalizeEmail(),
+    body("password").notEmpty().withMessage("Password is required"),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ error: errors.array()[0].msg });
+    }
 
-  if (!email || !password) {
-    return res.status(400).json({ error: "Email and password are required" });
+    const { email, password } = req.body;
+
+    try {
+      const user = await User.findOne({ email, role: "campus-rep" });
+      if (!user || !(await user.comparePassword(password))) {
+        return res.status(401).json({ error: "Invalid campus rep credentials" });
+      }
+
+      const token = signToken(user);
+
+      return res.status(200).json({
+        message: "Campus rep login successful",
+        token,
+        user: { id: user._id, name: user.fullName, email: user.email, role: "campus-rep" },
+      });
+    } catch (err) {
+      return res.status(500).json({ error: "Server error" });
+    }
   }
+);
 
-  const rep = campusReps.find((r) => r.email === email && r.password === password);
-  if (!rep) {
-    return res.status(401).json({ error: "Invalid campus rep credentials" });
+// PATCH /api/auth/role
+router.patch("/role", protect, async (req, res) => {
+  const { role } = req.body;
+  if (!["student", "campus-rep"].includes(role)) {
+    return res.status(400).json({ error: "Invalid role" });
   }
-
-  return res.status(200).json({
-    message: "Campus rep login successful",
-    user: { id: rep.id, name: rep.name, email: rep.email, role: "campus-rep" },
-  });
+  try {
+    const user = await User.findByIdAndUpdate(req.user.id, { role }, { new: true });
+    if (!user) return res.status(404).json({ error: "User not found" });
+    const token = signToken(user);
+    return res.status(200).json({
+      message: "Role updated",
+      token,
+      user: { id: user._id, fullName: user.fullName, email: user.email, role: user.role },
+    });
+  } catch {
+    return res.status(500).json({ error: "Server error" });
+  }
 });
 
 module.exports = router;

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const cors = require("cors");
+const mongoose = require("mongoose");
 require("dotenv").config();
 
 const authRoutes = require("./routes/auth.js");
@@ -12,10 +13,15 @@ const adminRoutes = require("./routes/adminRoutes");
 const app = express();
 const PORT = process.env.PORT || 5001;
 
+mongoose
+  .connect(process.env.MONGO_URI)
+  .then(() => console.log("MongoDB connected"))
+  .catch((err) => console.error("MongoDB connection error:", err));
+
 app.use(cors());
 app.use(express.json());
 
-app.get("/", (req, res) => {
+app.get("/", (_req, res) => {
   res.json({ message: "Syllabus+ API is running" });
 });
 

--- a/front-end/src/context/AuthContext.jsx
+++ b/front-end/src/context/AuthContext.jsx
@@ -4,17 +4,20 @@ const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
 
-  function login(userData) {
+  function login(userData, authToken) {
     setUser(userData);
+    setToken(authToken);
   }
 
   function logout() {
     setUser(null);
+    setToken(null);
   }
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, token, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/front-end/src/pages/RoleSection-Signup.jsx
+++ b/front-end/src/pages/RoleSection-Signup.jsx
@@ -1,8 +1,37 @@
-import React from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 const RoleSelectionScreen = () => {
   const navigate = useNavigate();
+  const { token, login } = useAuth();
+  const [error, setError] = useState('');
+
+  const handleRoleSelect = async (role, path) => {
+    setError('');
+    try {
+      const res = await fetch('http://localhost:5001/api/auth/role', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ role }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || 'Could not update role');
+        return;
+      }
+
+      login(data.user, data.token);
+      navigate(path);
+    } catch {
+      setError('Could not connect to server');
+    }
+  };
 
   return (
     <div className="auth-page">
@@ -13,13 +42,15 @@ const RoleSelectionScreen = () => {
         </div>
 
         <div className="role-selection-options">
-          <button className="role-card" onClick={() => navigate('/student-details')}>
+          <button className="role-card" onClick={() => handleRoleSelect('student', '/student-details')}>
             STUDENT
           </button>
-          <button className="role-card" onClick={() => navigate('/campus-rep-details')}>
+          <button className="role-card" onClick={() => handleRoleSelect('campus-rep', '/campus-rep-details')}>
             CAMPUS REP
           </button>
         </div>
+
+        {error && <p className="auth-error">{error}</p>}
 
         <button className="back-link" onClick={() => navigate('/signup')}>Back</button>
       </div>

--- a/front-end/src/pages/SignUp.jsx
+++ b/front-end/src/pages/SignUp.jsx
@@ -45,7 +45,7 @@ function Signup() {
         return;
       }
 
-      login(data.user);
+      login(data.user, data.token);
       navigate("/role-selection");
     } catch {
       setError("Could not connect to server");


### PR DESCRIPTION
## What this PR does
- Replaced in-memory user store with MongoDB Atlas (Mongoose)
- Added User model with bcrypt password hashing
- JWT token issued on signup and login (7-day expiry)
- Input validation on all auth endpoints using express-validator
- Added JWT auth middleware for protecting routes
- Connected Mongoose to MongoDB Atlas in server.js
- Credentials stored in .env (excluded from version control)

## Endpoints
- POST /api/auth/signup
- POST /api/auth/login
- POST /api/auth/campus-rep/login
- PATCH /api/auth/role (JWT protected)
