### PR TITLE
Extra-Credit: Add CI workflow - GitHub Actions for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  backend-test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo:6
+        ports:
+          - 27017:27017
+
+    env:
+      MONGO_URI: mongodb://localhost:27017/testdb
+      JWT_SECRET: ci-test-secret
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: back-end/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: back-end
+
+      - name: Run backend tests
+        run: npm test
+        working-directory: back-end
+
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: front-end/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: front-end
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: front-end
+        env:
+          CI: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-          cache: "npm"
-          cache-dependency-path: back-end/package-lock.json
 
       - name: Install backend dependencies
-        run: npm ci
+        run: npm install
         working-directory: back-end
 
       - name: Run backend tests
@@ -50,11 +48,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-          cache: "npm"
-          cache-dependency-path: front-end/package-lock.json
 
       - name: Install frontend dependencies
-        run: npm ci
+        run: npm install
         working-directory: front-end
 
       - name: Build frontend
@@ -62,3 +58,4 @@ jobs:
         working-directory: front-end
         env:
           CI: false
+          REACT_APP_API_URL: http://localhost:5001

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "c8": "^11.0.0",
-    "chai": "^6.2.2",
+    "chai": "^4.3.10",
     "mocha": "^11.7.5",
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2"


### PR DESCRIPTION
added a github actions CI workflow that automatically runs our backend tests and builds the frontend every time someone pushes or opens a PR

what it does:
spins up a mongodb instance and runs all our mocha tests on the backend
builds the react frontend to catch any compile errors
runs on every push to any branch and every new PR
this gets us the extra credit for continuous integration